### PR TITLE
Add activate and deactivate commands for all toggles

### DIFF
--- a/src/features/ActivateDimming.ts
+++ b/src/features/ActivateDimming.ts
@@ -1,0 +1,10 @@
+import { Command } from "@/features/base/Command";
+
+export class ActivateDimming extends Command {
+	protected commandKey = "activate-paragraph-dimming";
+	protected commandTitle = "Activate paragraph dimming";
+
+	protected onCommand(): void {
+		this.plugin.features.DimUnfocusedParagraphs.toggle(true);
+	}
+}

--- a/src/features/ActivateFullscreenWritingFocus.ts
+++ b/src/features/ActivateFullscreenWritingFocus.ts
@@ -1,0 +1,21 @@
+import type { ItemView } from "obsidian";
+import { FullscreenWritingFocus } from "./FullscreenWritingFocus";
+
+export class ActivateFullscreenWritingFocus extends FullscreenWritingFocus {
+protected override commandKey = "activate-fullscreen-writing-focus";
+	protected override commandTitle = "Activate fullscreen writing focus";
+
+	protected override onCommand(): void {
+		const leaf = this.plugin.app.workspace.activeLeaf;
+		const view = leaf.view as ItemView;
+		if (view.getViewType() === "empty") return;
+
+		if (!document.fullscreenElement) {
+			this.startFullscreenWritingFocus(view);
+		}
+
+		view.containerEl.onfullscreenchange = () => {
+			if (!document.fullscreenElement) this.onExitFullscreenWritingFocus();
+		};
+	}
+}

--- a/src/features/ActivateTypewriter.ts
+++ b/src/features/ActivateTypewriter.ts
@@ -1,0 +1,10 @@
+import { Command } from "@/features/base/Command";
+
+export class ActivateTypewriter extends Command {
+	protected commandKey = "activate-typewriter";
+	protected commandTitle = "Activate typewriter scrolling";
+
+	protected onCommand(): void {
+		this.plugin.features.TypewriterScroll.toggle(true);
+	}
+}

--- a/src/features/ActivateTypewriterAndDimming.ts
+++ b/src/features/ActivateTypewriterAndDimming.ts
@@ -1,0 +1,11 @@
+import { Command } from "@/features/base/Command";
+
+export class ActivateTypewriterAndDimming extends Command {
+	protected commandKey = "activate-typewriter-scrolling-and-paragraph-dimming";
+	protected commandTitle = "Activate typewriter scrolling and paragraph dimming";
+
+	protected onCommand(): void {
+		this.plugin.features.TypewriterScroll.toggle(true);
+		this.plugin.features.DimUnfocusedParagraphs.toggle(true);
+	}
+}

--- a/src/features/DeactivateDimming.ts
+++ b/src/features/DeactivateDimming.ts
@@ -1,0 +1,10 @@
+import { Command } from "@/features/base/Command";
+
+export class DeactivateDimming extends Command {
+	protected commandKey = "deactivate-paragraph-dimming";
+	protected commandTitle = "Deactivate paragraph dimming";
+
+	protected onCommand(): void {
+		this.plugin.features.DimUnfocusedParagraphs.toggle(false);
+	}
+}

--- a/src/features/DeactivateFullscreenWritingFocus.ts
+++ b/src/features/DeactivateFullscreenWritingFocus.ts
@@ -1,0 +1,21 @@
+import type { ItemView } from "obsidian";
+import { FullscreenWritingFocus } from "./FullscreenWritingFocus";
+
+export class DeactivateFullscreenWritingFocus extends FullscreenWritingFocus {
+protected override commandKey = "deactivate-fullscreen-writing-focus";
+	protected override commandTitle = "Deactivate fullscreen writing focus";
+
+	protected override onCommand(): void {
+		const leaf = this.plugin.app.workspace.activeLeaf;
+		const view = leaf.view as ItemView;
+		if (view.getViewType() === "empty") return;
+
+		if (document.fullscreenElement) {
+			this.exitFullscreenWritingFocus();
+		}
+
+		view.containerEl.onfullscreenchange = () => {
+			if (!document.fullscreenElement) this.onExitFullscreenWritingFocus();
+		};
+	}
+}

--- a/src/features/DeactivateTypewriter.ts
+++ b/src/features/DeactivateTypewriter.ts
@@ -1,0 +1,10 @@
+import { Command } from "@/features/base/Command";
+
+export class DeactivateTypewriter extends Command {
+	protected commandKey = "deactivate-typewriter";
+	protected commandTitle = "Deactivate typewriter scrolling";
+
+	protected onCommand(): void {
+		this.plugin.features.TypewriterScroll.toggle(false);
+	}
+}

--- a/src/features/DeactivateTypewriterAndDimming.ts
+++ b/src/features/DeactivateTypewriterAndDimming.ts
@@ -1,0 +1,11 @@
+import { Command } from "@/features/base/Command";
+
+export class DeactivateTypewriterAndDimming extends Command {
+	protected commandKey = "deactivate-typewriter-scrolling-and-paragraph-dimming";
+	protected commandTitle = "Deactivate typewriter scrolling and paragraph dimming";
+
+	protected onCommand(): void {
+		this.plugin.features.TypewriterScroll.toggle(false);
+		this.plugin.features.DimUnfocusedParagraphs.toggle(false);
+	}
+}

--- a/src/features/FullscreenWritingFocus.ts
+++ b/src/features/FullscreenWritingFocus.ts
@@ -19,7 +19,7 @@ export class FullscreenWritingFocus extends Command {
 		};
 	}
 
-	private startFullscreenWritingFocus(view: ItemView) {
+	protected startFullscreenWritingFocus(view: ItemView) {
 		const fullscreenEl = this.plugin.settings
 			.doesFullscreenWritingFocusShowHeader
 			? view.containerEl
@@ -33,11 +33,11 @@ export class FullscreenWritingFocus extends Command {
 		});
 	}
 
-	private exitFullscreenWritingFocus() {
+	protected exitFullscreenWritingFocus() {
 		document.exitFullscreen().then();
 	}
 
-	private onExitFullscreenWritingFocus() {
+	protected onExitFullscreenWritingFocus() {
 		const elements = document.getElementsByClassName(
 			"ptm-fullscreen-writing-focus-element",
 		);

--- a/src/features/commands.ts
+++ b/src/features/commands.ts
@@ -5,13 +5,29 @@ import { MoveTypewriter } from "@/features/MoveTypewriter";
 import { ToggleTypewriterAndDimming } from "@/features/ToggleTypewriterAndDimming";
 import { ToggleDimming } from "./ToggleDimming";
 import { ToggleTypewriter } from "./ToggleTypewriter";
+import { ActivateTypewriter } from "./ActivateTypewriter";
+import { DeactivateTypewriter } from "./DeactivateTypewriter";
+import { ActivateFullscreenWritingFocus } from "./ActivateFullscreenWritingFocus";
+import { DeactivateFullscreenWritingFocus } from "./DeactivateFullscreenWritingFocus";
+import { ActivateDimming } from "./ActivateDimming";
+import { DeactivateDimming } from "./DeactivateDimming";
+import { ActivateTypewriterAndDimming } from "./ActivateTypewriterAndDimming";
+import { DeactivateTypewriterAndDimming } from "./DeactivateTypewriterAndDimming";
 
 export function getCommands(plugin: TypewriterModePlugin) {
 	return {
 		ToggleTypewriter: new ToggleTypewriter(plugin),
+		ActivateTypewriter: new ActivateTypewriter(plugin),
+		DeactivateTypewriter: new DeactivateTypewriter(plugin),
 		ToggleDimming: new ToggleDimming(plugin),
+		ActivateDimming: new ActivateDimming(plugin),
+		DeactivateDimming: new DeactivateDimming(plugin),
 		ToggleTypewriterAndDimming: new ToggleTypewriterAndDimming(plugin),
+		ActivateTypewriterAndDimming: new ActivateTypewriterAndDimming(plugin),
+		DeactivateTypewriterAndDimming: new DeactivateTypewriterAndDimming(plugin),
 		MoveTypewriter: new MoveTypewriter(plugin),
 		FullscreenWritingFocus: new FullscreenWritingFocus(plugin),
+		ActivateFullscreenWritingFocus: new ActivateFullscreenWritingFocus(plugin),
+		DeactivateFullscreenWritingFocus: new DeactivateFullscreenWritingFocus(plugin),
 	};
 }


### PR DESCRIPTION
When combining commands in macros (using [Commander plugin](https://github.com/phibr0/obsidian-commander)), it's useful to be able to activate or deactivate things, not just toggling, to avoid getting out of sync with other statuses (e.g.: snippet commands).