### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,9 @@ on:
       - "**"
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/davisriedel/obsidian-typewriter-mode/security/code-scanning/2](https://github.com/davisriedel/obsidian-typewriter-mode/security/code-scanning/2)

To fix the problem, explicitly declare a `permissions` block limiting the `GITHUB_TOKEN` to the minimal required rights. This can be done at the workflow root (applies to all jobs) or at the job level. Since there is a single job and it only needs to read the repository contents for `actions/checkout`, we can add `permissions: contents: read` at the workflow level, right after the `name` (or after `on:`), without changing any existing behavior.

Concretely, edit `.github/workflows/check.yml` to insert:

```yaml
permissions:
  contents: read
```

near the top of the file, before the `jobs:` section. No other methods, imports, or definitions are needed, and the steps of the job remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
